### PR TITLE
Add extra fields for Event and Registrations tables in ActiveAdmin

### DIFF
--- a/app/admin/events.rb
+++ b/app/admin/events.rb
@@ -7,6 +7,10 @@ ActiveAdmin.register Event do
     column :lesson
     column :teacher_github_username
     column :start_time
+    column 'Registered Students' do |event|
+      event.total_students
+    end
+    column :class_size
     actions
   end
 end

--- a/app/admin/registrations.rb
+++ b/app/admin/registrations.rb
@@ -6,6 +6,7 @@ ActiveAdmin.register Registration do
     id_column
     column :registrant
     column :event
+    column :number_of_students
     column :created_at
     actions
   end


### PR DESCRIPTION
Specifically, `Events` now show the total number of students registered and the class size (available registrants). Viewing a `Registration` also shows the number of students associated with that `Registration`.
