### PR TITLE
Fix broken newsletter messaging (success/failure messages)

### DIFF
--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -1,9 +1,15 @@
 $(function () {
 
-  var $newsletter = $('#newsletter'),
+  var $newsletter = $('#newsletter-form'),
       $newsletterInput = $('.js-newsletter-input'),
       $newsletterSubmit = $('.js-newsletter-submit'),
       $newsletterResponse = $('.js-newsletter-result');
+
+  $newsletter.on('submit', function () {
+    if ($newsletterInput.val() === '') {
+      return false;
+    }
+  });
 
   $newsletter.on('ajax:success', function (xhr, response) {
     $newsletterInput.val('');

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -268,26 +268,6 @@ input[type="number"]::-webkit-inner-spin-button {
 .home__newsletter {
   @include trailer;
 
-  label { @extend %screen-reader-text; }
-  
-  input[type="email"] {
-    @include trailer(0.5);
-  }
-
-  input[type="email"],
-  input[type="submit"] {
-    display: block;
-    width: 100%;
-  }
-
-  @include media($above-layout-m) {
-    input[type="email"],
-    input[type="submit"] {
-      display: inline-block;
-      width: auto;
-    }
-  }
-
   @include media($above-layout-l) {
     @include span-columns(3);
   }
@@ -374,20 +354,20 @@ input[type="number"]::-webkit-inner-spin-button {
   clear: both;
   @include padding-leader;
 
-  input[type="text"],
+  input[type="number"],
   input[type="email"],
   input[type="submit"] {
     display: block;
     width: 100%;
   }
 
-  input[type="text"],
+  input[type="number"],
   input[type="email"] {
     @include trailer(0.5);
   }
   
   @include media($above-layout-m) {
-    input[type="text"],
+    input[type="number"],
     input[type="email"],
     input[type="submit"] {
       display: inline-block;
@@ -404,6 +384,28 @@ input[type="number"]::-webkit-inner-spin-button {
 .past-lessons {
   @extend %section;
   @include row;
+}
+
+.newsletter {
+  label { @extend %screen-reader-text; }
+  
+  input[type="email"] {
+    @include trailer(0.5);
+  }
+
+  input[type="email"],
+  input[type="submit"] {
+    display: block;
+    width: 100%;
+  }
+
+  @include media($above-layout-m) {
+    input[type="email"],
+    input[type="submit"] {
+      display: inline-block;
+      width: auto;
+    }
+  }
 }
 
 // ----------------------------------------------------------------------------

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -40,13 +40,7 @@
   <div class="home__newsletter">
     <h1 id="newsletter">Register for updates</h1>
     <p>Sign up to our mailing list to keep up to date with planned classes.</p>
-    
-    <%= form_tag "/newsletters/announcements", method: "post", remote: true, id: "newsletter", class: "newsletter-form mt1" do %>
-      <%= label_tag "email", "Email" %>
-      <%= email_field_tag "email", nil, placeholder: "Email address", class: "js-newsletter-input" %>
-      <%= submit_tag "Register", class: "btn btn--primary js-newsletter-submit" %>
-      <p class="js-newsletter-result">&nbsp;</p>
-    <% end %>
+    <%= render partial: "shared/newsletter" %>
   </div>
 
   <div class="home__get-involved">

--- a/app/views/lessons/_lesson.html.erb
+++ b/app/views/lessons/_lesson.html.erb
@@ -46,9 +46,10 @@
           <%= submit_tag "Register", class: "btn btn--primary" %>
         <% end %>
       <% else %>
-        <h2>Registration Closed</h2>
+        <h2>Registration is Full</h2>
 
         <p>Subscribe to our <a href="/#newsletter">newsletter</a> to receive announcements about future classes.</p>
+        <%= render partial: "shared/newsletter" %>
       <% end %>
     </div>
   <% end %>

--- a/app/views/shared/_newsletter.html.erb
+++ b/app/views/shared/_newsletter.html.erb
@@ -1,0 +1,6 @@
+<%= form_tag "/newsletters/announcements", method: "post", remote: true, id: "newsletter-form", class: 'newsletter' do %>
+  <%= label_tag "email", "Email" %>
+  <%= email_field_tag "email", nil, placeholder: "Email address", class: "js-newsletter-input" %>
+  <%= submit_tag "Register", class: "btn btn--primary js-newsletter-submit" %>
+  <p class="js-newsletter-result">&nbsp;</p>
+<% end %>


### PR DESCRIPTION
Fixed issue where newsletter success/failure messages weren't showing due to outdated JS. Changed "Registration is Closed" to "Registration is Full" after getting some emails about confusion with the wording (is it **full** or just **closed**?). Refactored the newsletter form itself into a partial so that we can include it directly with the "Registration is Full" message rather than linking back to the homepage.
