### PR TITLE
Display multiple upcoming events

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,9 +1,7 @@
 class HomeController < ApplicationController
   def index
     @page_class = "home"
-    @lesson = if @event = Event.upcoming
-      @event.lesson
-    end
+    @upcoming_events = Event.upcoming(2)
     @list_id = ENV["MAILCHIMP_LIST_ID"]
   end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -71,11 +71,18 @@ class Event < ActiveRecord::Base
     event_subscribers.where(sent_at: nil)
   end
 
-  # Public: Upcoming event if one exists.
+  # Public: Upcoming events, if they exist
   #
-  # Returns an Event or NilClass.
-  def self.upcoming
-    where("start_time > ?", Time.now).order("start_time ASC").first
+  # count - the number of upcoming events to return
+  #
+  # Returns an array of up to `count` Events or NilClass.
+  def self.upcoming (count = 1)
+    events = where("start_time > ?", Time.now).order("start_time ASC")
+    if events.empty?
+      nil
+    else
+      events.take(count)
+    end
   end
 
   # Public: Is registration open for this event?

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -76,13 +76,8 @@ class Event < ActiveRecord::Base
   # count - the number of upcoming events to return
   #
   # Returns an array of up to `count` Events or NilClass.
-  def self.upcoming (count = 1)
-    events = where("start_time > ?", Time.now).order("start_time ASC")
-    if events.empty?
-      nil
-    else
-      events.take(count)
-    end
+  def self.upcoming(count = 1)
+    where("start_time > ?", Time.now).order("start_time ASC").first(count)
   end
 
   # Public: Is registration open for this event?

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -28,10 +28,12 @@
   </div>
 </section>
 
-<% if @event.present? %>
+<% if @upcoming_events.present? %>
+  <h1>Upcoming <%= "Event".pluralize(@upcoming_events.count) %></h1>
   <section class="home__upcoming">
-    <h1>Upcoming Event</h1>
-    <%= render partial: "lessons/lesson", object: @lesson if @lesson.present? %>
+    <% @upcoming_events.each { |event| %>
+      <%= render partial: "lessons/lesson", object: event.lesson if event.lesson.present? %>
+    <% } %>
   </section>
 <% end %>
 

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -28,7 +28,7 @@
   </div>
 </section>
 
-<% if @upcoming_events.present? %>
+<% if @upcoming_events.any? %>
   <h1>Upcoming <%= "Event".pluralize(@upcoming_events.count) %></h1>
   <section class="home__upcoming">
     <% @upcoming_events.each { |event| %>

--- a/test/acceptance/home/index_test.rb
+++ b/test/acceptance/home/index_test.rb
@@ -2,13 +2,33 @@ require "minitest_helper"
 
 class HomeIndexTest < AcceptanceTest
   it "renders the homepage" do
-    event = Event.make!
+    events = [Event.make!]
 
     visit "/"
 
     must_have_content "CoderDojo San Francisco"
     must_have_content "View all lessons"
-    must_have_content event.lesson.title
-    must_have_content event.lesson.summary
+    must_have_content events.first.lesson.title
+    must_have_content events.first.lesson.summary
+  end
+  
+  it "pluralizes the 'Upcoming Event' heading when appropriate" do
+    events = [Event.make!]
+    visit "/"
+    must_have_content "Upcoming Event"
+    
+    events.push(Event.make!)
+    visit "/"
+    must_have_content "Upcoming Events"
+  end
+
+  it "renders up to two upcoming events" do
+    events = [Event.make!, Event.make!, Event.make!]
+    
+    visit "/"
+    
+    must_have_content events[0].lesson.title
+    must_have_content events[1].lesson.title
+    wont_have_content events[2].lesson.title
   end
 end

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -39,8 +39,8 @@ describe Event do
   end
 
   describe "#upcoming" do
-    it "returns nil if there is no upcoming event" do
-      assert_nil Event.upcoming
+    it "returns an empty array if there is no upcoming event" do
+      assert_empty Event.upcoming
     end
 
     it "returns upcoming event if it exists" do

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -48,7 +48,7 @@ describe Event do
       event = Event.make!(start_time: 1.days.from_now)
       Event.make!(start_time: 2.day.from_now)
 
-      assert_equal event, Event.upcoming
+      assert_equal event, Event.upcoming.first
     end
   end
 


### PR DESCRIPTION
Adds the ability to display multiple upcoming events on the homepage. In our
case, and as implemented by these changes, we will display 2 upcoming events.
The static `Event.upcoming` method now accepts a parameter, `count`, to support
returning multiple upcoming events. `count` defaults to 1. Adds or updates
appropriate tests, and slightly changes view logic in the
`home/index.html.erb` view.
